### PR TITLE
Update the link to the Shodan website

### DIFF
--- a/config/shodan.spc
+++ b/config/shodan.spc
@@ -2,7 +2,7 @@ connection "shodan" {
   plugin = "shodan"
 
   # Shodan requires an API key for all requests, but offers a free tier.
-  # Sign up on the Shodan website (https://shodan.com) to get your free
+  # Sign up on the Shodan website (https://account.shodan.io) to get your free
   # token (it looks like `ZGloRSAl6Tvur9tCTu44NkZIe1i5Cc5U`) and set it:
   #api_key  = "YOUR_API_KEY_HERE"
 }

--- a/docs/index.md
+++ b/docs/index.md
@@ -23,7 +23,7 @@ steampipe plugin install shodan
 
 ## Credentials
 
-Shodan requires an API token for all requests, but offers a free tier. Sign up on the [shodan website](https://shodan.com) to get your free token. It looks like `ZGloRBAl2Tvur3tBTu84NkZIf3i5Cc5U`.
+Shodan requires an API token for all requests, but offers a free tier. Sign up on the [Shodan website](https://www.shodan.io) to get your free token. It looks like `ZGloRBAl2Tvur3tBTu84NkZIf3i5Cc5U`.
 
 
 ## Connection Configuration


### PR DESCRIPTION
"shodan.com" doesn't belong to Shodan. The correct URL to get the API key is "https://account.shodan.io"

# Integration test logs
<details>
  <summary>Logs</summary>
  
```
Add passing integration test logs here
```
</details>

# Example query results
<details>
  <summary>Results</summary>
  
```
Add example SQL query results here (please include the input queries as well)
```
</details>
